### PR TITLE
Feature/last status update timestamp

### DIFF
--- a/src/ui/components/DoorDetail.tsx
+++ b/src/ui/components/DoorDetail.tsx
@@ -2,6 +2,7 @@ import Typography from '@mui/material/Typography';
 import { Door } from '@/models/Door';
 import { DetailPageContainer } from '@/ui/layout/DetailPageContainer';
 import { DetailPageItem } from '@/ui/layout/DetailPageItem';
+import { getLocaleString, DateTime } from '@/lib/dateTime';
 
 interface DoorDetailProps {
   door: Door;
@@ -29,6 +30,14 @@ export function DoorDetail({ door }: DoorDetailProps) {
           }
         >
           {door.connectionStatus}
+        </Typography>
+      </DetailPageItem>
+      <DetailPageItem label="Last Connection Status">
+        <Typography>
+          {getLocaleString(
+            door.lastConnectionStatusUpdate,
+            DateTime.DATETIME_FULL_WITH_SECONDS,
+          )}
         </Typography>
       </DetailPageItem>
     </DetailPageContainer>

--- a/src/ui/components/DoorList.tsx
+++ b/src/ui/components/DoorList.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { Door } from '@/models/Door';
 import { DataGrid, GridColDef, GridRowParams } from '@mui/x-data-grid';
 import Typography from '@mui/material/Typography';
+import { getLocaleString, DateTime } from '@/lib/dateTime';
 
 interface DoorListProps {
   doors: Door[];
@@ -41,6 +42,21 @@ const columns: GridColDef<Door>[] = [
           }
         >
           {door.connectionStatus}
+        </Typography>
+      );
+    },
+  },
+  {
+    field: 'lastConnectionStatusUpdate',
+    headerName: 'Last Connection Status',
+    flex: 1,
+    renderCell: ({ row: door }) => {
+      return (
+        <Typography fontSize="14px">
+          {getLocaleString(
+            door.lastConnectionStatusUpdate,
+            DateTime.DATETIME_SHORT,
+          )}
         </Typography>
       );
     },

--- a/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
@@ -84,5 +84,21 @@ exports[`DoorDetail should render correctly 1`] = `
       offline
     </p>
   </div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+    >
+      <strong>
+        Last Connection Status
+      </strong>
+    </p>
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+    >
+      February 22, 2023 at 5:00:11 AM GMT+2
+    </p>
+  </div>
 </div>
 `;

--- a/src/ui/components/__snapshots__/DoorList.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DoorList should render correctly 1`] = `
 <div
-  aria-colcount="5"
+  aria-colcount="6"
   aria-multiselectable="false"
   aria-rowcount="2"
   class="MuiDataGrid-root MuiDataGrid-autoHeight MuiDataGrid-root--densityStandard MuiDataGrid-withBorderColor css-5wly58-MuiDataGrid-root"


### PR DESCRIPTION
Show timestamp when the last door connection status was sent to the IoT server in a proper format (date and time) on the door list as well as on the detail page to provide additional information about the door connection health.